### PR TITLE
Convert uploaded files to JPEG format.

### DIFF
--- a/webcam/server.py
+++ b/webcam/server.py
@@ -37,7 +37,8 @@ class DenseCap(Resource):
       im = Image.open(BytesIO(base64.b64decode(img_data)))
       im.save(img_name)
     else:
-      request.files['image'].save(img_name)
+      im = Image.open(request.files['image'].stream)
+      im.save(img_name, 'JPEG')
     json_name = os.path.join(output_dir, '%d.json' % img_id)
     while not os.path.isfile(json_name):
       time.sleep(0.05)


### PR DESCRIPTION
保存前に一度ストリームを読み込んで，jpegに変換して保存する処理を加えました．
（が，そもそもjpegで受け取ることを前提にしているようなので，仕様通りに使う分には処理が増えるだけかもしれません．[参考](https://github.com/unnonouno/densecap/blob/master/webcam/web-client.js#L140)）