### PR TITLE
Add confidense scores to return dict of daemon.lua

### DIFF
--- a/webcam/daemon.lua
+++ b/webcam/daemon.lua
@@ -90,6 +90,7 @@ while true do
 
       local output_struct = {
         boxes = boxes_xywh:float():totable(),
+        scores = scores:float():view(-1):totable(),
         captions = captions,
         height = ori_H,
         width = ori_W,


### PR DESCRIPTION
Confidence scores of each bounding box may be important for subsequent processes.

I simply added same line as `run_model.lua`.
https://github.com/unnonouno/densecap/blob/master/run_model.lua#L92